### PR TITLE
fix: stop sending the same image over and over

### DIFF
--- a/src/Display.ts
+++ b/src/Display.ts
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 
 export default class Display {
   private readonly plugin: Plugin;
+  private lastText = { line1: '', line2: '' };
 
   constructor(plugin: Plugin) {
     this.plugin = plugin;
@@ -23,12 +24,19 @@ export default class Display {
       throw new Error('could not create 2d context in canvas');
     }
     const day = dayjs();
+    const line1 = day.format(settings.format1stLine);
+    const line2 = day.format(settings.format2ndLine);
+    if (this.lastText.line1 === line1 && this.lastText.line2 === line2) {
+      return;
+    }
+    this.lastText.line1 = line1;
+    this.lastText.line2 = line2;
     context.fillStyle = 'white';
     context.font = `40px "${settings.font}"`;
     context.textAlign = 'center';
-    context.fillText(day.format(settings.format1stLine), 72, 60, 144);
+    context.fillText(line1, 72, 60, 144);
     context.font = `28px "${settings.font}"`;
-    context.fillText(day.format(settings.format2ndLine), 72, 110, 144);
+    context.fillText(line2, 72, 110, 144);
     this.plugin.setImage(canvas.toDataURL('image/png'), pluginContext);
   }
 }


### PR DESCRIPTION
now we keep track of the last image we sent to the streamdeck to display
the current time and we wont send it again as long it doesnt changes