### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/build-test-versions.yml
+++ b/.github/workflows/build-test-versions.yml
@@ -4,20 +4,34 @@ on: [ push, pull_request ]
 
 jobs:
   build:
+    name: build/test on node versions
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [ 14.x, 16.x, 17.x ]
+        node-version: [ 14.x, 16.x, 18.x, 19.x ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # 2.0.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            nodejs.org:443
+            registry.yarnpkg.com:443
+
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # 3.5.1
         with:
           node-version: ${{ matrix.node-version }}
+
       - run: yarn install
       - run: yarn type-check
       - run: yarn lint

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,68 +1,55 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: "Code Scanning - Action"
 
 on:
   push:
     # Dependabot triggered push events have read-only access, but uploading code scanning requires write access.
     branches-ignore: [dependabot/**]
   pull_request:
+    branches: [main]
 
 jobs:
-  analyze:
-    name: Analyze
+  CodeQL-Build:
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
+
     permissions:
-      actions: read
-      contents: read
+      # required for all workflows
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # 2.0.0
+        with:
+          egress-policy: audit
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@aa0e650c6a3f17884f81106e54e207cc0f669aa2 # 2.11.5
+        # Override language selection by uncommenting this and choosing your languages
+        # with:
+        #   languages: go, javascript, csharp, python, cpp, java, ruby
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below).
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@aa0e650c6a3f17884f81106e54e207cc0f669aa2 # 2.11.5
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following
+      #    three lines and modify them (or add more) to build your code if your
+      #    project uses a compiled language
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      #- run: |
+      #     make bootstrap
+      #     make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@aa0e650c6a3f17884f81106e54e207cc0f669aa2 # 2.11.5

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,30 @@
+name: Lint Commit Messages
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  commitlint:
+    if: github.actor != 'dependabot[bot]'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # 2.0.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Lint
+        uses: wagoid/commitlint-github-action@481aff4de4d0de6d28d05533d4230d298ea3377d # 5.3.0
+        with:
+          configFile: package.json
+          failOnWarnings: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,19 +2,52 @@ name: Release
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+
 jobs:
   release:
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # 2.0.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        with:
+          persist-credentials: false
+
+      - name: Install Node
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # 3.5.1
         with:
           node-version: 16
-      - run: yarn install
-      - run: yarn build-prod
-      - name: Release
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build plugin
+        run: yarn build-prod
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@8f6ceb9d5aae5578b1dcda6af00008235204e7fa # 3.2
+        id: semantic
+        with:
+          semantic_version: 19.0.2
+          branch: main
+          extra_plugins: |
+            @semantic-release/changelog@6.0.2
+            @semantic-release/exec@6.0.3
+            @amille/semantic-release-plugins@3.3.12
+            @semantic-release/git@10.0.1
+            conventional-changelog-conventionalcommits@5.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn semantic-release --branches main
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: Outputs
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          echo release version: ${{ steps.semantic.outputs.new_release_version }}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,23 +1,52 @@
 name: Test-Release
 
-on: [ push ]
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   release:
+    name: test release
 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v5
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # 2.0.0
         with:
-          node-version: 16
-      - run: yarn install
-      - name: Release Test
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+
+      - name: Get branch name
+        uses: tj-actions/branch-names@a594c1e96eab7790611fdaf5bc8f76ea55cedabd # 6.3
+        id: branch-name
+
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@8f6ceb9d5aae5578b1dcda6af00008235204e7fa # 3.2
+        id: semantic
+        with:
+          dry_run: true
+          semantic_version: 19.0.2
+          branch: ${{ steps.branch-name.outputs.current_branch }}
+          extra_plugins: |
+            @semantic-release/changelog@6.0.2
+            @semantic-release/exec@6.0.3
+            @amille/semantic-release-plugins@3.3.12
+            @semantic-release/git@10.0.1
+            conventional-changelog-conventionalcommits@5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-        run: yarn semantic-release --dry-run --branches ${{ steps.branch-name.outputs.current_branch }}
+
+      - name: Test Outputs
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          echo release version: ${{ steps.semantic.outputs.new_release_version }}

--- a/release.config.js
+++ b/release.config.js
@@ -5,7 +5,9 @@ module.exports = {
     [
       '@semantic-release/commit-analyzer',
       {
+        preset: 'conventionalcommits',
         releaseRules: [
+          { breaking: true, release: 'major' },
           { type: 'chore', release: 'patch' },
           { type: 'docs', release: 'patch' },
           { type: 'refactor', release: 'patch' },


### PR DESCRIPTION
- most versions of the used actions are deprecated -> update to newest
- use harden-runner
- use semantic-release action so we don't have to rely on whatever the packaged files are doing